### PR TITLE
Feature contributor conflict

### DIFF
--- a/elifearticle/article.py
+++ b/elifearticle/article.py
@@ -181,7 +181,7 @@ class Contributor(BaseObject):
     given_name = None
     suffix = None
     collab = None
-    conflict = None
+    conflict = []
     group_author_key = None
 
     def __new__(cls, contrib_type, surname, given_name, collab=None):
@@ -194,13 +194,14 @@ class Contributor(BaseObject):
         self.surname = surname
         self.given_name = given_name
         self.affiliations = []
+        self.conflict = []
         self.collab = collab
 
     def set_affiliation(self, affiliation):
         self.affiliations.append(affiliation)
 
     def set_conflict(self, conflict):
-        self.conflict = conflict
+        self.conflict.append(conflict)
 
 
 class Affiliation(BaseObject):

--- a/tests/test_article.py
+++ b/tests/test_article.py
@@ -135,7 +135,10 @@ class TestContributor(unittest.TestCase):
     def test_set_conflict(self):
         conflict = "A conflict"
         self.contributor.set_conflict(conflict)
-        self.assertEqual(self.contributor.conflict, conflict)
+        self.assertEqual(self.contributor.conflict, [conflict])
+        # add another one
+        self.contributor.set_conflict(conflict)
+        self.assertEqual(self.contributor.conflict, [conflict, conflict])
 
 
 class TestAffiliation(unittest.TestCase):

--- a/tests/test_parse_deep.py
+++ b/tests/test_parse_deep.py
@@ -98,6 +98,9 @@ class TestParseDeep(unittest.TestCase):
         self.assertEqual(article_object.contributors[0].suffix, 'Jnr')
         # first contributor contributed equally
         self.assertEqual(article_object.contributors[0].equal_contrib, True)
+        # first contributor has one conflict of interest
+        self.assertEqual(len(article_object.contributors[0].conflict), 1)
+        self.assertEqual(article_object.contributors[0].conflict, ['Chair of JATS4R'])
         # ethics - not parsed yet
         self.assertEqual(len(article_object.ethics), 0)
         # compare dates


### PR DESCRIPTION
Allow a Contributor to have multiple conflict of interest values, and parse the competing interests from XML files to populate it.