### PR TITLE
Affiliations refactoring

### DIFF
--- a/elifearticle/parse.py
+++ b/elifearticle/parse.py
@@ -46,40 +46,19 @@ def build_contributors(authors, contrib_type, competing_interests=None):
         if author.get("equal-contrib") == "yes":
             contributor.equal_contrib = True
 
-        # Affiliations, compile text for each
-        department = []
-        institution = []
-        city = []
-        country = []
-        text = []
-
+        # Add contributor affiliations
         if author.get("affiliations"):
             for aff in author.get("affiliations"):
-                department.append(aff.get("dept"))
-                institution.append(aff.get("institution"))
-                city.append(aff.get("city"))
-                country.append(aff.get("country"))
-                text.append(aff.get("text"))
-
-        # Turn the set of lists into ContributorAffiliation
-        for index in range(0, len(institution)):
-            affiliation = ea.Affiliation()
-            affiliation.department = department[index]
-            affiliation.institution = institution[index]
-            affiliation.city = city[index]
-            affiliation.country = country[index]
-
-            affiliation.text = utils.text_from_affiliation_elements(
-                affiliation.department,
-                affiliation.institution,
-                affiliation.city,
-                affiliation.country)
-
-            # fall back if no other fields are set take the text content
-            if affiliation.text == '':
-                affiliation.text = text[index]
-
-            contributor.set_affiliation(affiliation)
+                affiliation = ea.Affiliation()
+                affiliation.text = utils.text_from_affiliation_elements(
+                    aff.get("dept"),
+                    aff.get("institution"),
+                    aff.get("city"),
+                    aff.get("country"))
+                # fall back if no other fields are set take the text content
+                if affiliation.text == '':
+                    affiliation.text = aff.get("text")
+                contributor.set_affiliation(affiliation)
 
         # competing interests / conflicts
         if (competing_interests and author.get("references")

--- a/elifearticle/parse.py
+++ b/elifearticle/parse.py
@@ -47,18 +47,17 @@ def build_contributors(authors, contrib_type, competing_interests=None):
             contributor.equal_contrib = True
 
         # Add contributor affiliations
-        if author.get("affiliations"):
-            for aff in author.get("affiliations"):
-                affiliation = ea.Affiliation()
-                affiliation.text = utils.text_from_affiliation_elements(
-                    aff.get("dept"),
-                    aff.get("institution"),
-                    aff.get("city"),
-                    aff.get("country"))
-                # fall back if no other fields are set take the text content
-                if affiliation.text == '':
-                    affiliation.text = aff.get("text")
-                contributor.set_affiliation(affiliation)
+        for aff in author.get("affiliations", []):
+            affiliation = ea.Affiliation()
+            affiliation.text = utils.text_from_affiliation_elements(
+                aff.get("dept"),
+                aff.get("institution"),
+                aff.get("city"),
+                aff.get("country"))
+            # fall back if no other fields are set take the text content
+            if affiliation.text == '':
+                affiliation.text = aff.get("text")
+            contributor.set_affiliation(affiliation)
 
         # competing interests / conflicts
         if (competing_interests and author.get("references")

--- a/elifearticle/parse.py
+++ b/elifearticle/parse.py
@@ -51,6 +51,7 @@ def build_contributors(authors, contrib_type, competing_interests=None):
         institution = []
         city = []
         country = []
+        text = []
 
         if author.get("affiliations"):
             for aff in author.get("affiliations"):
@@ -58,6 +59,7 @@ def build_contributors(authors, contrib_type, competing_interests=None):
                 institution.append(aff.get("institution"))
                 city.append(aff.get("city"))
                 country.append(aff.get("country"))
+                text.append(aff.get("text"))
 
         # Turn the set of lists into ContributorAffiliation
         for index in range(0, len(institution)):
@@ -72,6 +74,10 @@ def build_contributors(authors, contrib_type, competing_interests=None):
                 affiliation.institution,
                 affiliation.city,
                 affiliation.country)
+
+            # fall back if no other fields are set take the text content
+            if affiliation.text == '':
+                affiliation.text = text[index]
 
             contributor.set_affiliation(affiliation)
 

--- a/elifearticle/utils.py
+++ b/elifearticle/utils.py
@@ -145,10 +145,5 @@ def author_name_from_json(author_json):
 
 def text_from_affiliation_elements(department, institution, city, country):
     "format an author affiliation from details"
-    text = ""
-    for element in (department, institution, city, country):
-        if text != "":
-            text += ", "
-        if element:
-            text += element
-    return text
+    return ', '.join(element for element in [department, institution, city, country]
+                     if element is not None)

--- a/elifearticle/utils.py
+++ b/elifearticle/utils.py
@@ -145,5 +145,4 @@ def author_name_from_json(author_json):
 
 def text_from_affiliation_elements(department, institution, city, country):
     "format an author affiliation from details"
-    return ', '.join(element for element in [department, institution, city, country]
-                     if element is not None)
+    return ', '.join(element for element in [department, institution, city, country] if element)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ git+https://github.com/elifesciences/elife-tools.git@3ebc42f10d6ec54724ecdd9cd8d
 coverage==3.7.1
 arrow==0.4.4
 GitPython==2.1.7
+ddt==1.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/elifesciences/elife-tools.git@6a83ccdeae75f4575769375636cd4b240850369e#egg=elifetools
+git+https://github.com/elifesciences/elife-tools.git@3ebc42f10d6ec54724ecdd9cd8da4f54c9124000#egg=elifetools
 coverage==3.7.1
 arrow==0.4.4
 GitPython==2.1.7

--- a/tests/test_parse_deep.py
+++ b/tests/test_parse_deep.py
@@ -16,7 +16,8 @@ class TestParseDeep(unittest.TestCase):
 
     def test_parse_article_02935_simple(self):
         "some simple comparisons and count list items"
-        article_object, error_count = parse.build_article_from_xml(XLS_PATH + 'elife-02935-v2.xml')
+        article_object, error_count = parse.build_article_from_xml(XLS_PATH + 'elife-02935-v2.xml',
+                                                                   detail='full')
         # test pretty method for test coverage
         self.assertIsNotNone(article_object.pretty())
         # list of individual comparisons of interest
@@ -34,6 +35,10 @@ class TestParseDeep(unittest.TestCase):
         self.assertEqual(article_object.contributors[0].suffix, None)
         # first contributor did not contribute equally
         self.assertEqual(article_object.contributors[0].equal_contrib, False)
+        # first contributor affiliation
+        self.assertEqual(
+            article_object.contributors[0].affiliations[0].text,
+            'Cancer Genome Project, Wellcome Trust Sanger Institute, Hinxton, United Kingdom')
         # ethics - not parsed yet
         self.assertEqual(len(article_object.ethics), 0)
         # compare dates
@@ -89,7 +94,8 @@ class TestParseDeep(unittest.TestCase):
 
     def test_parse_article_00666_simple(self):
         "some simple comparisons and count list items"
-        article_object, error_count = parse.build_article_from_xml(XLS_PATH + 'elife-00666.xml')
+        article_object, error_count = parse.build_article_from_xml(XLS_PATH + 'elife-00666.xml',
+                                                                   detail='full')
         # list of individual comparisons of interest
         self.assertEqual(article_object.doi, '10.7554/eLife.00666')
         self.assertEqual(article_object.journal_issn, '2050-084X')
@@ -110,6 +116,10 @@ class TestParseDeep(unittest.TestCase):
         # first contributor has one conflict of interest
         self.assertEqual(len(article_object.contributors[0].conflict), 1)
         self.assertEqual(article_object.contributors[0].conflict, ['Chair of JATS4R'])
+        # first contributor affiliation
+        self.assertEqual(
+            article_object.contributors[0].affiliations[0].text,
+            'Department of Production, eLife, Cambridge, United Kingdom')
         # ethics - not parsed yet
         self.assertEqual(len(article_object.ethics), 0)
         # compare dates

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -53,5 +53,13 @@ class TestUtils(unittest.TestCase):
     def test_get_last_commit_to_master(self):
         self.assertIsNotNone(utils.get_last_commit_to_master())
 
+    def test_text_from_affiliation_elements(self):
+        text_1 = utils.text_from_affiliation_elements(None, None, None, None)
+        self.assertEqual(text_1, '')
+        text_2 = utils.text_from_affiliation_elements('One', 'Two', 'Three', 'Four')
+        self.assertEqual(text_2, 'One, Two, Three, Four')
+        text_3 = utils.text_from_affiliation_elements('One', 'Two', None, 'Four')
+        self.assertEqual(text_3, 'One, Two, Four')
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,8 +2,10 @@ import unittest
 import re
 import os
 import time
+from ddt import ddt, data, unpack
 from elifearticle import utils
 
+@ddt
 class TestUtils(unittest.TestCase):
 
     def setUp(self):
@@ -53,13 +55,27 @@ class TestUtils(unittest.TestCase):
     def test_get_last_commit_to_master(self):
         self.assertIsNotNone(utils.get_last_commit_to_master())
 
-    def test_text_from_affiliation_elements(self):
-        text_1 = utils.text_from_affiliation_elements(None, None, None, None)
-        self.assertEqual(text_1, '')
-        text_2 = utils.text_from_affiliation_elements('One', 'Two', 'Three', 'Four')
-        self.assertEqual(text_2, 'One, Two, Three, Four')
-        text_3 = utils.text_from_affiliation_elements('One', 'Two', None, 'Four')
-        self.assertEqual(text_3, 'One, Two, Four')
+    @unpack
+    @data(
+        (None, None, None, None, ''),
+        ('', None, None, None, ''),
+        ('One', 'Two', 'Three', 'Four', 'One, Two, Three, Four'),
+        ('One', 'Two', None, 'Four', 'One, Two, Four'),
+        ('One', 'Two', '', 'Four', 'One, Two, Four')
+        )
+    def test_text_from_affiliation_elements(self, department, institution, city, country,
+                                            expected):
+        self.assertEqual(
+            utils.text_from_affiliation_elements(department, institution, city, country),
+            expected,
+            "{expected} not found testing {department}, {institution}, {city}, {country}".format(
+                expected=expected,
+                department=department,
+                institution=institution,
+                city=city,
+                country=country
+                )
+            )
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
To support plain text affiliations for the Crossref project, this incorporates the latest elifetools parser. In addition, I added some more tests specifically for affiliation values, refactored how they are set to be much simpler.