### PR TITLE
Data availability property

### DIFF
--- a/elifearticle/article.py
+++ b/elifearticle/article.py
@@ -82,6 +82,7 @@ class Article(BaseObject):
         self.related_articles = []
         self.version = None
         self.datasets = []
+        self.data_availability = None
         self.funding_awards = []
         self.funding_note = None
         self.journal_issn = None

--- a/elifearticle/parse.py
+++ b/elifearticle/parse.py
@@ -150,12 +150,9 @@ def build_data_availability(datasets_json):
     Given datasets in JSON format, get the data availability from it if present
     """
     data_availability = None
-    if 'availability' in datasets_json:
+    if 'availability' in datasets_json and datasets_json.get('availability'):
         # only expect one paragraph of text
-        try:
-            data_availability = datasets_json.get('availability')[0].get('text')
-        except IndexError:
-            pass
+        data_availability = datasets_json.get('availability')[0].get('text')
     return data_availability
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/elifesciences/elife-tools.git@3ebc42f10d6ec54724ecdd9cd8da4f54c9124000#egg=elifetools
+git+https://github.com/elifesciences/elife-tools.git@29542941ee88df8e93cd2dbd8a8956e5e5165386#egg=elifetools
 coverage==3.7.1
 arrow==0.4.4
 GitPython==2.1.7

--- a/tests/test_parse_build_datasets.py
+++ b/tests/test_parse_build_datasets.py
@@ -1,6 +1,7 @@
 import unittest
 import os
 import re
+from collections import OrderedDict
 from elifearticle import parse
 
 
@@ -12,10 +13,35 @@ class TestParseBuildDatasets(unittest.TestCase):
     def test_datasets_uri_to_doi(self):
         "test converting uri to doi value"
         # based on a dataset in elife-01201-v1
-        dataset_data = {'generated': [
+        datasets_data = {'generated': [
             {'uri': 'http://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE51740'},
             {'uri': 'http://dx.doi.org/10.5061/dryad.cv39v'},
         ]}
-        datasets = parse.build_datasets(dataset_data)
+        datasets = parse.build_datasets(datasets_data)
         self.assertEqual(datasets[0].doi, None)
         self.assertEqual(datasets[1].doi, '10.5061/dryad.cv39v')
+
+    def test_build_data_availability(self):
+        "test extracting the data availability statement"
+        statement = 'Availability statement'
+        expected = statement
+        datasets_data = OrderedDict([
+            ('availability', [
+                OrderedDict([
+                    ('type', 'paragraph'),
+                    ('text', statement)
+                    ])
+                ])
+            ])
+        data_availability = parse.build_data_availability(datasets_data)
+        self.assertEqual(data_availability, expected)
+
+    def test_build_data_availability_no_value(self):
+        "test extracting data availability encountering an IndexError"
+        statement = 'Availability statement'
+        expected = None
+        datasets_data = OrderedDict([
+            ('availability', '')
+            ])
+        data_availability = parse.build_data_availability(datasets_data)
+        self.assertEqual(data_availability, expected)


### PR DESCRIPTION
Adding the ``data_availability`` to the ``Article`` object, and setting it from data that would be returned by the parser ``datasets_json()`` function.

I also renamed ``dataset_json`` to ``datasets_json`` throughout for clearer terminology.

The support for ``data_availability`` is already deployed in the currently used library (PR https://github.com/elifesciences/elife-poa-xml-generation/pull/320) which I pushed through fast to add support for it immediately.

This one is not a rush. It will later be followed up by updates to https://github.com/elifesciences/ejp-csv-parser CSV parsing, and then https://github.com/elifesciences/jats-generator updates to create the new XML format.

First, the object property must be added (here in this PR).