### PR TITLE
Use reference uri_text attribute when appropriate

### DIFF
--- a/elifearticle/parse.py
+++ b/elifearticle/parse.py
@@ -202,6 +202,9 @@ def build_ref_list(refs):
         utils.set_attr_if_value(ref, 'elocation_id', reference.get('elocation-id'))
         # uri
         utils.set_attr_if_value(ref, 'uri', reference.get('uri'))
+        if not ref.uri:
+            # take uri value from uri_text
+            utils.set_attr_if_value(ref, 'uri', reference.get('uri_text'))
         # pmid
         utils.set_attr_if_value(ref, 'pmid', reference.get('pmid'))
         # isbn


### PR DESCRIPTION
Set the Article ``uri`` property, using the ``uri_text`` parser attribute if the reference has no ``uri`` attribute.

More directly related to issue https://github.com/elifesciences/elife-crossref-feed/issues/131, where a non-eLife XML example has a ``uri`` tag but no ``xlink:href`` attribute, for example

```
<uri>https://example.org/</uri>
```

I didn't include a specific example in the tests for this, though the line of code is covered when testing already according to coverage.


