### PR TITLE
Setup requires GitPython, and do not need arrow for anything.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 git+https://github.com/elifesciences/elife-tools.git@6c4f822ab8d1bed99c20da057a7907a6ad9a78ce#egg=elifetools
 coverage==3.7.1
-arrow==0.4.4
 GitPython==2.1.7
 ddt==1.1.0

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,8 @@ setup(name='elifearticle',
     packages=['elifearticle'],
     license = 'MIT',
     install_requires=[
-        "elifetools"
+        "elifetools",
+        "GitPython"
     ],
     url='https://github.com/elifesciences/elife-article',
     maintainer='eLife Sciences Publications Ltd.',


### PR DESCRIPTION
Small edit to what installing `elife-article` requires (include `GitPython` because it is used). 

`arrow` is not used anywhere in this library, so remove from `requirements.txt`.