### PR TITLE
Dataset assigning_authority

### DIFF
--- a/elifearticle/article.py
+++ b/elifearticle/article.py
@@ -266,6 +266,7 @@ class Dataset(BaseObject):
         self.title = None
         self.license_info = None
         self.accession_id = None
+        self.assigning_authority = None
         self.doi = None
         self.uri = None
         self.comment = None

--- a/elifearticle/parse.py
+++ b/elifearticle/parse.py
@@ -131,6 +131,8 @@ def build_datasets(datasets_json):
             utils.set_attr_if_value(dataset, 'doi', dataset_values.get('doi'))
             utils.set_attr_if_value(dataset, 'uri', dataset_values.get('uri'))
             utils.set_attr_if_value(dataset, 'accession_id', dataset_values.get('dataId'))
+            utils.set_attr_if_value(dataset, 'assigning_authority', 
+                                    dataset_values.get('assigningAuthority'))
             # authors
             if dataset_values.get('authors'):
                 # parse JSON format authors into author objects

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/elifesciences/elife-tools.git@6c4f822ab8d1bed99c20da057a7907a6ad9a78ce#egg=elifetools
+git+https://github.com/elifesciences/elife-tools.git@991bd2eed2af68192f5ae36f3c0c00ed8afb07c3#egg=elifetools
 coverage==3.7.1
 arrow==0.4.4
 GitPython==2.1.7

--- a/tests/test_parse_deep.py
+++ b/tests/test_parse_deep.py
@@ -143,7 +143,10 @@ class TestParseDeep(unittest.TestCase):
         self.assertEqual(article_object.datasets[0].title, 'xml-mapping')
         self.assertEqual(article_object.datasets[0].comment, 'Publicly available on GitHub')
         self.assertEqual(article_object.datasets[0].uri, 'https://github.com/elifesciences/XML-mapping/blob/master/elife-00666.xml')
+        self.assertEqual(article_object.datasets[0].assigning_authority, None)
         self.assertEqual(article_object.datasets[2].doi, '10.5061/dryad.cv323')
+        self.assertEqual(
+            article_object.datasets[2].assigning_authority, 'Dryad Digital Repository')
         # related_articles
         self.assertEqual(len(article_object.related_articles), 0)
         # funding


### PR DESCRIPTION
In reference to issue https://github.com/elifesciences/elife-pubmed-feed/issues/61 adding additional detail about datasets for PubMed deposits, add the `assigning_authority` to `Dataset` and parse the value from the XML. Expanded test case to check for values from the kitchen sink XML.

If tests are passing I will merge without review for such a small change.