### PR TITLE
Review articles parsing

### DIFF
--- a/elifearticle/article.py
+++ b/elifearticle/article.py
@@ -59,6 +59,7 @@ class Article(BaseObject):
         self.article_type = "research-article"
         self.display_channel = None
         self.doi = doi
+        self.id = None
         self.contributors = []
         self.title = title
         self.abstract = ""
@@ -91,6 +92,7 @@ class Article(BaseObject):
         self.version = None
         self.publisher_name = None
         self.issue = None
+        self.review_articles = []
 
     def add_contributor(self, contributor):
         self.contributors.append(contributor)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/elifesciences/elife-tools.git@991bd2eed2af68192f5ae36f3c0c00ed8afb07c3#egg=elifetools
+git+https://github.com/elifesciences/elife-tools.git@7f6f7d6210a731ec62c26ccbe92e86212e8f982e#egg=elifetools
 coverage==3.7.1
 GitPython==2.1.7
 ddt==1.1.0

--- a/tests/test_data/elife-00666.xml
+++ b/tests/test_data/elife-00666.xml
@@ -4096,7 +4096,9 @@ UPDATE: article-type has been changed from article-commentary to decision-letter
                 <article-title>Decision letter</article-title>
             </title-group>
 <!-- NOTE: repetition of the reviewing editor in this section is required as it indicates that person is the author of this sub-article.
-UPDATE: punctuation between institution and country removed. -->     
+UPDATE: punctuation between institution and country removed.
+            NOTE: Where reveiwing editor and senior editor are the same person, on the website these 
+            will be consiolidated into one role: Senior and Reviewing Editor -->     
             <contrib-group>
                 <contrib contrib-type="editor">
                     <name>
@@ -4105,8 +4107,32 @@ UPDATE: punctuation between institution and country removed. -->
                     </name>
                     <role>Reviewing Editor</role>
                     <aff>
-                        <institution>eLife</institution>
-                        <country>United Kingdom</country>
+                        <institution>eLife Sciences</institution>
+                        <country country="GB">United Kingdom</country>
+                    </aff>
+                </contrib>
+            </contrib-group>
+            <contrib-group>
+                <contrib contrib-type="reviewer">
+                    <name>
+                        <surname>Darian-Smith</surname>
+                        <given-names>Corinna </given-names>
+                    </name>
+                    <role>Reviewer</role>
+                    <aff>
+                        <institution>Stanford University</institution>
+                        <country country="US">United States</country>
+                    </aff>
+                </contrib>
+                <contrib contrib-type="reviewer">
+                    <name>
+                        <surname>Smith</surname>
+                        <given-names>Alison M.</given-names>
+                    </name>
+                    <role>Reviewer</role>
+                    <aff>
+                        <institution>John Innes Centre</institution>
+                        <country country="GB">United Kingdom</country>
                     </aff>
                 </contrib>
             </contrib-group>

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -58,7 +58,7 @@ class TestParseXml(unittest.TestCase):
         build_parts = [
             'abstract', 'basic', 'categories', 'components', 'contributors', 'datasets', 'funding',
             'history', 'is_poa', 'keywords', 'license', 'pub_dates', 'references',
-            'related_articles', 'research_organisms', 'volume']
+            'related_articles', 'research_organisms', 'volume', 'sub_articles']
         article_xmls = [os.path.join(XLS_PATH, 'elife-02043-v2.xml')]
         article = parse.build_articles_from_article_xmls(article_xmls, detail, build_parts)[0]
         check_article(article)

--- a/tests/test_parse_deep.py
+++ b/tests/test_parse_deep.py
@@ -55,6 +55,32 @@ class TestParseDeep(unittest.TestCase):
         # datasets
         self.assertEqual(len(article_object.datasets), 2)
         self.assertEqual(article_object.datasets[0].accession_id, 'EGAS00001000968')
+        # review_articles
+        self.assertEqual(len(article_object.review_articles), 2)
+        # review_article 1
+        self.assertEqual(article_object.review_articles[0].doi, '10.7554/eLife.02935.027')
+        self.assertEqual(article_object.review_articles[0].article_type, 'article-commentary')
+        self.assertEqual(article_object.review_articles[0].id, 'SA1')
+        self.assertEqual(article_object.review_articles[0].title, 'Decision letter')
+        self.assertEqual(
+            article_object.review_articles[0].license.href,
+            'http://creativecommons.org/publicdomain/zero/1.0/')
+        self.assertEqual(len(article_object.review_articles[0].contributors), 1)
+        self.assertEqual(article_object.review_articles[0].contributors[0].surname, "Golub")
+        self.assertEqual(article_object.review_articles[0].contributors[0].given_name, "Todd")
+        self.assertEqual(article_object.review_articles[0].contributors[0].contrib_type, "editor")
+        self.assertEqual(
+            article_object.review_articles[0].contributors[0].affiliations[0].text,
+            "Broad Institute, United States")
+        self.assertEqual(
+            article_object.review_articles[0].related_articles[0].doi, "10.7554/eLife.02935")
+        self.assertEqual(
+            article_object.review_articles[0].related_articles[0].article_type, "research-article")
+        # review_articles 2
+        self.assertEqual(article_object.review_articles[1].doi, '10.7554/eLife.02935.028')
+        self.assertEqual(article_object.review_articles[1].article_type, 'reply')
+        self.assertEqual(article_object.review_articles[1].id, 'SA2')
+        self.assertEqual(article_object.review_articles[1].title, 'Author response')
         # related_articles
         self.assertEqual(len(article_object.related_articles), 0)
         # funding
@@ -147,6 +173,10 @@ class TestParseDeep(unittest.TestCase):
         self.assertEqual(article_object.datasets[2].doi, '10.5061/dryad.cv323')
         self.assertEqual(
             article_object.datasets[2].assigning_authority, 'Dryad Digital Repository')
+        # review_articles
+        self.assertEqual(len(article_object.review_articles), 2)
+        self.assertEqual(article_object.review_articles[0].doi, '10.7554/eLife.00666.029')
+        self.assertEqual(article_object.review_articles[1].doi, '10.7554/eLife.00666.030')
         # related_articles
         self.assertEqual(len(article_object.related_articles), 0)
         # funding
@@ -233,4 +263,5 @@ class TestParseDeep(unittest.TestCase):
         self.assertEqual(article_object.manuscript, '77')
         # publisher_id pii
         self.assertEqual(article_object.pii, None)
-
+        # review_articles, should be empty
+        self.assertEqual(len(article_object.review_articles), 0)

--- a/tests/test_parse_deep.py
+++ b/tests/test_parse_deep.py
@@ -177,6 +177,14 @@ class TestParseDeep(unittest.TestCase):
         self.assertEqual(len(article_object.review_articles), 2)
         self.assertEqual(article_object.review_articles[0].doi, '10.7554/eLife.00666.029')
         self.assertEqual(article_object.review_articles[1].doi, '10.7554/eLife.00666.030')
+        # review_article 1
+        self.assertEqual(len(article_object.review_articles[0].contributors), 3)
+        self.assertEqual(article_object.review_articles[0].contributors[0].surname, 'Collings')
+        self.assertEqual(article_object.review_articles[0].contributors[0].contrib_type, 'editor')
+        self.assertEqual(article_object.review_articles[0].contributors[1].surname, 'Darian-Smith')
+        self.assertEqual(article_object.review_articles[0].contributors[1].contrib_type, 'reviewer')
+        self.assertEqual(article_object.review_articles[0].contributors[2].surname, 'Smith')
+        self.assertEqual(article_object.review_articles[0].contributors[2].contrib_type, 'reviewer')
         # related_articles
         self.assertEqual(len(article_object.related_articles), 0)
         # funding


### PR DESCRIPTION
Building on the updated `elife-tools` library, here is logic to populate an `Article` `review_articles` property with the values of `<sub-article>` tags.

This follows eLife style of including some peer review materials in the research article XML itself.

Assertions added to `tests/test_parse_deep.py` are to confirm the attributes of the `review_articles` are parsed correctly.

The `tests/test_data/elife-00666.xml` test fixture is updated to reflect the most recent Decision letter data, since it includes an editor and reviewer contrib values, it is something that will be encountered in the `"real world"`.

The data structures and parsing logic is to support issue https://github.com/elifesciences/elife-crossref-feed/issues/123, to partially populate objects for depositing peer reviews to Crossref. There is additional data we will mix in later, such as the review date, that is not present in the article XML.