### PR TITLE
State support for Python 3.5 and travis-ci it too.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 
 python:
   - "2.7"
+  - "3.5"
 # command to install dependencies
 install: ./travis-install.sh
 script: ./travis-test.sh

--- a/setup.py
+++ b/setup.py
@@ -17,12 +17,13 @@ setup(name='elifearticle',
     ],
     url='https://github.com/elifesciences/elife-article',
     maintainer='eLife Sciences Publications Ltd.',
-    maintainer_email='py@elifesciences.org',
+    maintainer_email='tech-team@elifesciences.org',
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: MIT License",
         "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3.5",
         ]
     )


### PR DESCRIPTION
Re issue discussing Python 3 support https://github.com/elifesciences/elife-tools/issues/315

Here, test on travis-ci in `py35` as well. This project has been tested on `py35` for a long time now with no error.

Also updating `setup.py` to state the support in `3.5`, and update the contact email to the more current address in use.