### PR TITLE
Tweak to setup.py stating Python 3 support.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setup(name='elifearticle',
         "License :: OSI Approved :: MIT License",
         "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.5",
         ]
     )


### PR DESCRIPTION
Follow-up to PR https://github.com/elifesciences/elife-article/pull/52, state Python 3 major version in `setup.py`.