### PR TITLE
Add ContentBlock object.

### DIFF
--- a/elifearticle/article.py
+++ b/elifearticle/article.py
@@ -5,7 +5,7 @@ Article object definitions
 from six import iteritems
 
 from collections import OrderedDict
-
+from elifetools import utils as etoolsutils
 from elifearticle.utils import is_str_or_unicode, unicode_value
 
 class BaseObject(object):
@@ -436,3 +436,34 @@ class Uri(BaseObject):
     def init(self):
         self.xlink_href = None
         self.content_type = None
+
+
+class ContentBlock(object):
+    def __new__(cls, block_type=None, content=None, attr=None):
+        new_instance = object.__new__(cls)
+        new_instance.init(block_type, content, attr)
+        return new_instance
+
+    def init(self, block_type=None, content=None, attr=None):
+        self.block_type = block_type
+        self.content = content
+        self.content_blocks = []
+        self.attr = {}
+        if attr:
+            self.attr = attr
+
+    def attr_names(self):
+        """list of tag attribute names"""
+        if self.attr:
+            return list(self.attr.keys())
+        return []
+
+    def attr_string(self):
+        """tag attributes formatted as a string"""
+        string = ''
+        if self.attr:
+            for key, value in sorted(self.attr.items()):
+                attr = '%s="%s"' % (
+                    key, etoolsutils.escape_ampersand(value).replace('"', '&quot;'))
+                string = ' '.join([string, attr])
+        return string

--- a/tests/test_article.py
+++ b/tests/test_article.py
@@ -259,9 +259,20 @@ class TestRelatedArticle(unittest.TestCase):
         self.assertIsNotNone(self.related_article)
 
 
+class TestContentBlock(unittest.TestCase):
 
+    def test_content_block(self):
+        """test blank content block"""
+        content_block = ea.ContentBlock()
+        self.assertEqual(content_block.attr_names(), [])
 
-
+    def test_content_block_attr(self):
+        """test attributes function"""
+        content_block = ea.ContentBlock("disp-quote", None, {"content-type": "editor-comment"})
+        content_block.attr["escaped"] = "\""
+        self.assertEqual(sorted(content_block.attr_names()), ["content-type", "escaped"])
+        self.assertEqual(
+            content_block.attr_string(), ' content-type="editor-comment" escaped="&quot;"')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Re issue https://github.com/elifesciences/decision-letter-parser/issues/23

`ContentBlock` was created for populating JATS XML content in the decision letter parser. Now its attributes and functions are well tested in that parsing library, it is moved here for potential reuse (if ever) by other libraries.