### PR TITLE
Article.digest property added, is already in use.

### DIFF
--- a/elifearticle/article.py
+++ b/elifearticle/article.py
@@ -45,6 +45,7 @@ class Article(BaseObject):
         self.editors = []
         self.title = title
         self.abstract = ""
+        self.digest = None
         self.research_organisms = []
         self.manuscript = None
         self.dates = {}


### PR DESCRIPTION
Unexpected errors running tests in PR https://github.com/elifesciences/elife-pubmed-xml-generation/pull/36, because `Article.digest` property did not exist.

The property's value is set by `elifearticle/parse.py` when parsing an XML file, if there is a digest for the article, but otherwise the `Article` object is missing the property.

I think it is better for the property to exist by default, with `None` as its value, until it is set a value, if applicable.