### PR TITLE
Refactor attr names and string function for reuse.

### DIFF
--- a/elifearticle/article.py
+++ b/elifearticle/article.py
@@ -3,7 +3,8 @@ Article object definitions
 """
 
 from collections import OrderedDict
-from elifetools import utils as etoolsutils
+from elifearticle import utils
+
 
 class BaseObject(object):
     "base object for shared functions"
@@ -436,16 +437,8 @@ class ContentBlock(object):
 
     def attr_names(self):
         """list of tag attribute names"""
-        if self.attr:
-            return list(self.attr.keys())
-        return []
+        return utils.attr_names(self.attr)
 
     def attr_string(self):
         """tag attributes formatted as a string"""
-        string = ''
-        if self.attr:
-            for key, value in sorted(self.attr.items()):
-                attr = '%s="%s"' % (
-                    key, etoolsutils.escape_ampersand(value).replace('"', '&quot;'))
-                string = ' '.join([string, attr])
-        return string
+        return utils.attr_string(self.attr)

--- a/elifearticle/utils.py
+++ b/elifearticle/utils.py
@@ -5,6 +5,7 @@ Utility functions for converting content and some shared by other libraries
 import re
 import os
 from git import Repo, InvalidGitRepositoryError, NoSuchPathError
+from elifetools import utils as etoolsutils
 
 
 def repl(match):
@@ -57,6 +58,25 @@ def replace_tags(string, from_tag='i', to_tag='italic'):
     string = string.replace('<' + from_tag + '>', '<' + to_tag + '>')
     string = string.replace('</' + from_tag + '>', '</' + to_tag + '>')
     return string
+
+
+def attr_names(attr_map):
+    """return a list of attribute names from the map"""
+    if attr_map:
+        return list(attr_map.keys())
+    return []
+
+
+def attr_string(attr_map):
+    """string of tag attributes and values"""
+    string = ''
+    if attr_map:
+        for key, value in sorted(attr_map.items()):
+            attr = '%s="%s"' % (
+                key, etoolsutils.escape_ampersand(value).replace('"', '&quot;'))
+            string = ' '.join([string, attr])
+    return string
+
 
 def set_attr_if_value(obj, attr_name, value):
     "shorthand method to set object values if the value is not none"

--- a/elifearticle/utils.py
+++ b/elifearticle/utils.py
@@ -63,7 +63,7 @@ def replace_tags(string, from_tag='i', to_tag='italic'):
 def attr_names(attr_map):
     """return a list of attribute names from the map"""
     if attr_map:
-        return list(attr_map.keys())
+        return list(sorted(attr_map.keys()))
     return []
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -84,5 +84,28 @@ class TestUtils(unittest.TestCase):
                 )
             )
 
+
+class TestUtilsAttr(unittest.TestCase):
+
+    def setUp(self):
+        self.attr_map = {
+            'foo': '& bar',
+            'more': '"complicated"'
+            }
+
+    def test_attr_names(self):
+        self.assertEqual(utils.attr_names(self.attr_map), ['foo', 'more'])
+
+    def test_attr_names_blank(self):
+        self.assertEqual(utils.attr_names(None), [])
+
+    def test_attr_string(self):
+        expected = ' foo="&amp; bar" more="&quot;complicated&quot;"'
+        self.assertEqual(utils.attr_string(self.attr_map), expected)
+
+    def test_attr_blank(self):
+        self.assertEqual(utils.attr_string(None), '')
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Some fairly new logic in the `ContentBlock` object which takes a `dict` of tag attributes as a map and returns a list of the attribute names as well as a concatenated string of attributes for use in an XML tag.

There's a spot in the PubMed generation library where these would be useful, so here I've spun them out into the `utils.py` module for potential reuse by other libraries.

Explict tests for the two, as well as existing tests in this library pass.

These functions work for most expected input, and if we need them to be more robust, it is good to rely on these in a centralised location, and they can be improved.