### PR TITLE
Update elifetools library version used.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/elifesciences/elife-tools.git@eae816f0bd20d92209327ed72c7519eb428770a5#egg=elifetools
+git+https://github.com/elifesciences/elife-tools.git@aa63d17bed20bc039c12c4b0b371db6aedf0937a#egg=elifetools
 coverage==5.1
 GitPython==3.1.2
 ddt==1.1.0


### PR DESCRIPTION
The latest `elifetools` parser can include structured abstracts data in the `abstract_json()` function, but `elife-article` project is still using the older `abstract()` call. This PR is mostly to confirm compatibility with the `elifetools` parser, as well as one step toward better support for structured abstracts later.