### PR TITLE
ClinicalTrial object, parse values from XML.

### DIFF
--- a/elifearticle/article.py
+++ b/elifearticle/article.py
@@ -422,14 +422,9 @@ class Uri(BaseObject):
         self.content_type = None
 
 
-class ClinicalTrial(object):
+class ClinicalTrial(BaseObject):
 
-    def __new__(cls):
-        new_instance = object.__new__(cls)
-        new_instance.init()
-        return new_instance
-
-    def init(self):
+    def __init__(self):
         self.id = None
         self.content_type = None
         self.document_id = None

--- a/elifearticle/article.py
+++ b/elifearticle/article.py
@@ -77,6 +77,7 @@ class Article(BaseObject):
         self.publisher_name = None
         self.issue = None
         self.review_articles = []
+        self.clinical_trials = []
 
     def add_contributor(self, contributor):
         self.contributors.append(contributor)
@@ -419,6 +420,40 @@ class Uri(BaseObject):
     def init(self):
         self.xlink_href = None
         self.content_type = None
+
+
+class ClinicalTrial(object):
+
+    def __new__(cls):
+        new_instance = object.__new__(cls)
+        new_instance.init()
+        return new_instance
+
+    def init(self):
+        self.id = None
+        self.content_type = None
+        self.document_id = None
+        self.document_id_type = None
+        self.source_id = None
+        self.source_id_type = None
+        self.source_type = None
+        self.text = None
+        self.xlink_href = None
+        self.registry_doi = None
+
+    def get_registry_doi(self, registry_name_to_doi_map=None):
+        """return the DOI for the registry"""
+        if self.registry_doi:
+            return self.registry_doi
+        elif self.source_id_type and self.source_id and self.source_id_type == 'crossref-doi':
+            return self.source_id
+        elif (
+                registry_name_to_doi_map and self.source_id_type and
+                self.source_id and self.source_id_type == 'registry-name'):
+            # look for the DOI value in the name to DOI map
+            if self.source_id in registry_name_to_doi_map:
+                return registry_name_to_doi_map[self.source_id]
+        return None
 
 
 class ContentBlock(object):

--- a/elifearticle/parse.py
+++ b/elifearticle/parse.py
@@ -412,6 +412,27 @@ def build_self_uri_list(self_uri_list):
     return uri_list
 
 
+def build_clinical_trials(clinical_trials):
+    clinical_trial_list = []
+    for clinical_trial in clinical_trials:
+        clinical_trial_object = ea.ClinicalTrial()
+        attr_map = {
+            'id': 'id',
+            'content-type': 'content_type',
+            'document-id': 'document_id',
+            'document-id-type': 'document_id_type',
+            'source-id': 'source_id',
+            'source-id-type': 'source_id_type',
+            'source-type': 'source_type',
+            'text': 'text',
+            'xlink_href': 'xlink_href',
+        }
+        for dict_key, attr_name in attr_map.items():
+            utils.set_attr_if_value(clinical_trial_object, attr_name, clinical_trial.get(dict_key))
+        clinical_trial_list.append(clinical_trial_object)
+    return clinical_trial_list
+
+
 def clean_abstract(abstract, remove_tags=['xref', 'ext-link', 'inline-formula', 'mml:*']):
     """
     Remove unwanted tags from abstract string,
@@ -498,6 +519,10 @@ def build_article_from_xml(article_xml_filename, detail="brief",
     # publisher_name
     if build_part('basic'):
         article.publisher_name = parser.publisher(soup)
+
+    # publisher_name
+    if build_part('basic'):
+        article.clinical_trials = build_clinical_trials(parser.clinical_trials(soup))
 
     # abstract
     if build_part('abstract'):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/elifesciences/elife-tools.git@aa63d17bed20bc039c12c4b0b371db6aedf0937a#egg=elifetools
+git+https://github.com/elifesciences/elife-tools.git@141ccae952165238c94c46609b5608b190cead0e#egg=elifetools
 coverage==5.1
 GitPython==3.1.2
 ddt==1.1.0

--- a/tests/test_parse_build_clinical_trials.py
+++ b/tests/test_parse_build_clinical_trials.py
@@ -1,0 +1,61 @@
+import unittest
+from collections import OrderedDict
+from elifearticle import parse
+
+
+REGISTRY_NAME_TO_DOI_MAP = OrderedDict([
+    ('ClinicalTrials.gov', '10.18810/clinical-trials-gov')
+])
+
+
+class TestParseBuildClinicalTrials(unittest.TestCase):
+
+    def setUp(self):
+        self.clinical_trials_data = [
+            OrderedDict([
+                ('id', 'CT1'),
+                ('content-type', 'post-result'),
+                ('document-id', 'NCT02836002'),
+                ('document-id-type', 'clinical-trial-number'),
+                ('source-id', 'ClinicalTrials.gov'),
+                ('source-id-type', 'registry-name'),
+                ('source-type', 'clinical-trials-registry'),
+                ('text', 'NCT02836002'),
+                ('xlink_href', 'https://clinicaltrials.gov/show/NCT02836002'),
+                ]),
+            OrderedDict([
+                ('id', 'CT1'),
+                ('content-type', 'preResult'),
+                ('document-id', 'NCT04094727'),
+                ('document-id-type', 'clinical-trial-number'),
+                ('source-id', '10.18810/clinical-trials-gov'),
+                ('source-id-type', 'crossref-doi'),
+                ('source-type', 'clinical-trials-registry'),
+                ('text', 'NCT04094727'),
+                ('xlink_href', 'https://clinicaltrials.gov/show/NCT04094727'),
+                ])
+            ]
+
+    def test_build_clinical_trials(self):
+        "test building ClinicalTrial objects from clinical trials data"
+        clinical_trials = parse.build_clinical_trials(self.clinical_trials_data)
+        self.assertEqual(len(clinical_trials), 2)
+        # spot check a few values
+        self.assertEqual(
+            clinical_trials[0].xlink_href, 'https://clinicaltrials.gov/show/NCT02836002')
+        self.assertEqual(clinical_trials[0].get_registry_doi(), None)
+        self.assertEqual(clinical_trials[1].document_id, 'NCT04094727')
+        self.assertEqual(clinical_trials[1].get_registry_doi(), '10.18810/clinical-trials-gov')
+
+    def test_build_clinical_trials_registry_doi_map(self):
+        "build clinicial trials data then get a registry doi using the registry name to doi map"
+        clinical_trials = parse.build_clinical_trials(self.clinical_trials_data)
+        # override a value for checking test coverage
+        registry_doi = 'injected_value'
+        clinical_trials[1].registry_doi = registry_doi
+        self.assertEqual(
+            clinical_trials[0].get_registry_doi(REGISTRY_NAME_TO_DOI_MAP),
+            '10.18810/clinical-trials-gov')
+        self.assertEqual(
+            clinical_trials[1].get_registry_doi(REGISTRY_NAME_TO_DOI_MAP),
+            registry_doi)


### PR DESCRIPTION
New object definition for `ClinicalTrial()`, contains a set of the standard properties, as well as some logic for getting the registry DOI it's associated with. 

The value can either be set directly (as the `registry_doi` property), if it's `source_id_type` is "crossref-doi" then the `source_id` will be the registry DOI. If not, and the `source_id_type` is "registry-name", and we pass in a name to DOI map, we can look up the registry DOI for the registry name.

The `parse.py` module will take the values parsed from article XML using the `elifetools` XML parser and set the object values of `ClinicalTrial` objects.

I'm not sure I've asked you to review anything here before @lsh-0, if I may impose again.