### PR TITLE
Add abstract_xml and abstract_json properies.

### DIFF
--- a/elifearticle/article.py
+++ b/elifearticle/article.py
@@ -41,6 +41,8 @@ class Article(BaseObject):
         self.editors = []
         self.title = title
         self.abstract = ""
+        self.abstract_json = None
+        self.abstract_xml = None
         self.digest = None
         self.research_organisms = []
         self.manuscript = None

--- a/elifearticle/parse.py
+++ b/elifearticle/parse.py
@@ -527,6 +527,8 @@ def build_article_from_xml(article_xml_filename, detail="brief",
     # abstract
     if build_part('abstract'):
         article.abstract = clean_abstract(parser.full_abstract(soup), remove_tags)
+        article.abstract_json = parser.abstract_json(soup)
+        article.abstract_xml = parser.abstract_xml(soup)
 
     # digest
     if build_part('abstract'):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/elifesciences/elife-tools.git@141ccae952165238c94c46609b5608b190cead0e#egg=elifetools
+git+https://github.com/elifesciences/elife-tools.git@ffa1e5e8f25544c9d111e410728f6f3282f7be5c#egg=elifetools
 coverage==5.1
 GitPython==3.1.2
 ddt==1.1.0


### PR DESCRIPTION
Fixes https://github.com/elifesciences/issues/issues/5741

This is the glue in the middle of the new function in the `elifetools` parser which extracts abstract content in XML, and also throwing in the abstract JSON too which may be useful at some point.

The `abstract_xml` property will make it possible to deposit structured abstracts to Crossref and PubMed.